### PR TITLE
2차 디자인 개편 (3) + IRC 파서 교체

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
             <!--left panel-->
             <div class="left-panel">
                 <Dice v-show="state === 0" />
-                <div v-show="state === 1" v-if="payload"><Wheel :payload="payload"></Wheel></div>
+                <Wheel v-show="state === 1" v-if="payload" :payload="payload"></Wheel>
                 <Raffle v-show="state === 2" v-if="options.channel" :begin="started" :index="boardIndex" :channel="options.channel"></Raffle>
             </div>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -70,27 +70,27 @@
             </div>
 
             <!--free-->
-            <button
-                @keydown.prevent v-else-if="index === 13"
+            <div
+                v-else-if="index === 13"
                 class="blockButton centered"
-                @click="state = 0">뱅하싶</button>
+                @click="state = 0">뱅하싶</div>
 
             <!--golden key-->
-            <button
-                @keydown.prevent v-else-if="board.isGoldenKey(index)"
+            <div
+                v-else-if="board.isGoldenKey(index)"
                 class="blockButton centered"
-                @click="state = 1">황금열쇠</button>
+                @click="state = 1">황금열쇠</div>
 
             <!--islands-->
-            <button
-                @keydown.prevent v-else-if="index === 7 || index === 20"
+            <div
+                v-else-if="index === 7 || index === 20"
                 class="blockButton centered"
-                @click="select(index)">{{ board.selectAll(index).length }}</button>
+                @click="select(index)">{{ board.selectAll(index).length }}</div>
 
             <!--other blocks-->
             <template v-else>
                 <div class="block-content">{{ board.board[index] }}</div>
-                <button @keydown.prevent class="blockButton centered" @click="select(index)">{{ board.selectAll(index).length }}</button>
+                <div class="blockButton centered" @click="select(index)">{{ board.selectAll(index).length }}</div>
             </template>
         </div>
     </div>
@@ -410,6 +410,8 @@ export default {
             color: transparent;
             border: none;
             transition: all 0.1s ease-out;
+
+            user-select: none;
 
             &:hover {
                 background-color: rgba(255, 255, 255, 0.7);

--- a/src/App.vue
+++ b/src/App.vue
@@ -322,9 +322,6 @@ export default {
         height: 100%;
         overflow: auto;
     }
-    .center {
-        box-shadow: 0 0 0 1px black inset;
-    }
     .block {
         display: flex;
         position: relative;
@@ -425,7 +422,10 @@ export default {
         grid-area: 2 / 2 / 7 / 8;
         position: relative;
         display: grid;
-        grid-template-columns: 7fr 5fr;
+        grid-template-columns: 10fr 8fr;
+        gap: 40px;
+
+        box-shadow: 0 0 0 1px black inset;
 
         // background-image: url('./assets/RM2023SM.png');
         background-position: center;

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,7 +62,11 @@
             </header>
 
             <!--start-->
-            <div v-if="index === 0" style="width: 100%; height: 100%;" @click="closeAll(); switchScene(true)">
+            <div
+                v-if="index === 0"
+                style="width: 100%; height: 100%;"
+                @click="closeAll(); switchScene(true)"
+                @contextmenu.prevent="state = 2">
             </div>
 
             <!--free-->

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="board">
-        <div class="center block">
+        <div class="center">
             <!--left panel-->
             <div class="left-panel">
                 <Dice v-show="state === 0" />
@@ -62,8 +62,7 @@
             </header>
 
             <!--start-->
-            <div v-if="index === 0" style="width: 100%; height: 100%;">
-                <button @keydown.prevent class="blockButton centered" @click="closeAll(); switchScene(true)">출발</button>
+            <div v-if="index === 0" style="width: 100%; height: 100%;" @click="closeAll(); switchScene(true)">
             </div>
 
             <!--free-->
@@ -308,21 +307,26 @@ export default {
     height: 100vh;
 
     // grid
-    grid-template-columns: 316px repeat(6, 1fr) 316px;
-    grid-template-rows: 176px repeat(5, 1fr) 176px;
+    grid-template-columns: 320px repeat(6, 1fr) 320px;
+    grid-template-rows: 180px repeat(5, 1fr) 180px;
 
     // decoration
-    border: 2px solid;
+    box-shadow: 0 0 0 2px #000 inset;
     // background-color: lightgray;
 
     .left-panel, .right-panel {
         height: 100%;
         overflow: auto;
     }
+    .center {
+        box-shadow: 0 0 0 1px black inset;
+    }
     .block {
         display: flex;
-        border: 2px solid;
         position: relative;
+
+        background-color: #eee;
+        border: 1px solid black;
 
         &.top { flex-direction: column-reverse; }
         &.bottom { flex-direction: column; }
@@ -334,26 +338,22 @@ export default {
                 flex-direction: column;
             }
         }
-        &.left {
-            .block-header {
-                text-align: right;
-            }
+        &.left .block-header {
+            text-align: right;
         }
-        &.corner {
-            .block-header {
-                color: white;
-                mix-blend-mode: exclusion;
-            }
+        &.corner .block-header {
+            color: white;
+            mix-blend-mode: exclusion;
         }
         &.corner, &.golden {
             .block-header {
                 background: none !important;
+                box-shadow: none;
             }
             .block-prize {
                 display: none;
             }
         }
-
         &.djmax, &.circle {
             flex-direction: row-reverse;
 
@@ -375,6 +375,8 @@ export default {
             font-size: 24px;
             line-height: 24px;
             padding: 8px 10px;
+
+            box-shadow: 0 0 0 2px black;
         }
         .block-prize {
             font-size: 0.8em;
@@ -386,8 +388,6 @@ export default {
             align-items: center;
 
             flex-grow: 1;
-
-            background-color: #eee;
 
             white-space: pre-wrap;
             text-align: center;

--- a/src/components/Raffle.vue
+++ b/src/components/Raffle.vue
@@ -137,9 +137,10 @@ export default {
 
 <style lang="scss">
 .raffleContainer {
+    position: relative;
     display: grid;
     grid-template-rows: 48px minmax(0, 2fr) 1fr 48px;
-    width: 700px;
+    width: 100%;
     height: 100%;
 
     .raffleHeader {

--- a/src/components/Wheel.vue
+++ b/src/components/Wheel.vue
@@ -1,16 +1,18 @@
 <template>
-    <v-stage :config="{ width: 704, height: 704 }">
-        <v-layer>
-            <v-wedge v-for="(item, index) in options.options" :config="sectorConfig(index, item)"></v-wedge>
-            <v-text v-for="(item, index) in options.options" :config="textConfig(index, item)"></v-text>
-            <v-line :config="arrow"></v-line>
-        </v-layer>
-    </v-stage>
-    <div v-show="showResult" class="resultScreen">
-        <div class="label">다음 황금열쇠는</div>
-        <div class="value iidx-title large"><span>{{ result }}</span></div>
+    <div class="wheelContainer">
+        <v-stage :config="{ width: 640, height: 640 }">
+            <v-layer>
+                <v-wedge v-for="(item, index) in options.options" :config="sectorConfig(index, item)"></v-wedge>
+                <v-text v-for="(item, index) in options.options" :config="textConfig(index, item)"></v-text>
+                <v-line :config="arrow"></v-line>
+            </v-layer>
+        </v-stage>
+        <div v-if="showResult" class="resultScreen">
+            <div class="label">다음 황금열쇠는</div>
+            <div class="value iidx-title large"><span>{{ result }}</span></div>
+        </div>
+        <button @keydown.prevent v-show="showButton" class="wheelButton" @click="click">{{ buttonLabels[state] }}</button>
     </div>
-    <button @keydown.prevent v-show="showButton" class="wheelButton" @click="click">{{ buttonLabels[state] }}</button>
 </template>
 
 <script lang="ts">
@@ -41,7 +43,7 @@ export default {
             startAngle: 0,
             speed: 50,
             arrow: {
-                points: [586, 356, 606, 366, 606, 346],
+                points: [555, 320, 575, 330, 575, 310],
                 fill: 'black',
                 closed: true
             },
@@ -82,8 +84,8 @@ export default {
         // properties
         sectorConfig(index: number, item: option) {
             return {
-                x: 356,
-                y: 356,
+                x: 320,
+                y: 320,
                 radius: 240,
                 angle: item.count * this.options.unitAngle,
                 fill: item.color,
@@ -96,8 +98,8 @@ export default {
                 text: item.key,
                 fontSize: 16,
                 fontStyle: 'bold',
-                x: 356,
-                y: 356,
+                x: 320,
+                y: 320,
                 offsetX: -60,
                 offsetY: 8,
                 rotation: this.startAngle + this.options.sum(index) * this.options.unitAngle + item.count * this.options.unitAngle / 2
@@ -156,21 +158,35 @@ export default {
 </script>
 
 <style lang="scss">
+.wheelContainer {
+    position: relative;
+    height: 100%;
+
+    overflow: hidden;
+
+    > div:not([class]) {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+    }
+}
 .wheelButton {
     position: absolute;
+    bottom: 0;
+    left: 0;
+
     width: 140px;
     height: 40px;
-    left: 8px;
-    bottom: 8px;
 
-    // decoration
-    border: none;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: white;
     font-size: 20px;
-    background-color: rgba(148, 255, 127, 0.75);
     transition: all 0.2s ease-out;
 
     &:hover {
-        background-color: rgb(148, 255, 127);
+        background-color: white;
+        color: black;
     }
 }
 
@@ -182,10 +198,10 @@ export default {
     gap: 1em;
 
     position: absolute;
-    width: 656px;
-    height: 600px;
-    left: 32px;
-    top: 32px;
+    width: 100%;
+    height: calc(100% - 48px);
+    left: 0;
+    top: 0;
     padding: 12px 16px;
 
     background-color: #000e;

--- a/src/stores/BoardStore.ts
+++ b/src/stores/BoardStore.ts
@@ -17,7 +17,7 @@ export const useBoardStore = defineStore('board', {
             // raffle pools
             pool: [] as vote[],
             islandPool: [] as vote[],
-            usedList: [] as { uid: string, song: string }[],
+            usedList: [] as vote[],
 
             // money
             money: 0,
@@ -212,7 +212,7 @@ export const useBoardStore = defineStore('board', {
             }
         },
         remove(target: vote) {
-            this.usedList.push({ uid: target.uid, song: target.song })
+            this.usedList.push(target)
             this.pool.filter(x => x.uid === target.uid).forEach(x => {
                 this.pool.splice(this.pool.indexOf(x), 1)
             })

--- a/src/stores/BoardStore.ts
+++ b/src/stores/BoardStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import * as LocalForage from 'localforage'
 
-import { parse } from "../scripts/IRC";
+import type { ParsedIRCMessage } from "./ConnectStore";
 
 const STEP_PRIZES = [35, 25, 15]
 const MONOPOLY_PRIZE = 30
@@ -17,7 +17,7 @@ export const useBoardStore = defineStore('board', {
             // raffle pools
             pool: [] as vote[],
             islandPool: [] as vote[],
-            usedList: [] as { name: string, song: string }[],
+            usedList: [] as { uid: string, song: string }[],
 
             // money
             money: 0,
@@ -138,71 +138,66 @@ export const useBoardStore = defineStore('board', {
         },
 
         // add votes
-        parse(msg: string): { name: string, status: 'accepted' | 'cooldown' | 'rejected' | 'failed' } {
-            const parsedMsg = parse(msg)
-            const match = parsedMsg.text.match(/!픽 (?<index>\d+) (?<song>.+)/)
-            if (match) {
-                const index = Number(match.groups?.index)
-                const excluded = [0, 13].concat(this.goldenKeys)
-                const map = [...Array(26).keys()].filter(x => !excluded.includes(x))
-                if (map.includes(index)) {
-                    return {
-                        name: parsedMsg.name,
-                        status: this.insert(parsedMsg.name, Number(match.groups?.index), String(match.groups?.song))
-                    }
-                } else {
-                    return {
-                        name: parsedMsg.name,
-                        status: 'rejected'
-                    }
-                }
+        parse({ tags, content, source }: ParsedIRCMessage): { name: string, status: 'accepted' | 'cooldown' | 'rejected' | 'failed' } {
+            const { groups: match } = content.match(/!픽 (?<index>\d+) (?<song>.+)/) ?? {}
+            const name = tags.display_name ?? source.nick
+            const uid = source.nick ?? source.full // i don't think this parse shall fail
+
+            if (!match)
+                return { name, status: 'failed' }
+
+            const index = Number(match.index)
+            const excluded = [0, 13].concat(this.goldenKeys)
+            const map = [...Array(26).keys()].filter(x => !excluded.includes(x))
+
+            if (map.includes(index)) {
+                const status = this.insert(uid, name, Number(match.index), match.song)
+                return { name, status }
             } else {
-                return {
-                    name: parsedMsg.name,
-                    status: 'failed'
-                }
+                return { name, status: 'rejected' }
             }
         },
-        insert(name: string, index: number, song: string) {
+        insert(uid: string, name: string, index: number, song: string) {
             const newVote = {
-                name: name,
+                uid,
+                name,
                 theme: this.board[index],
-                song: song,
+                song,
                 timestamp: Date.now()
             }
 
             // already picked
-            if (this.usedList.find(x => x.name === newVote.name)) return 'rejected'
+            if (this.usedList.find(x => x.uid === newVote.uid)) return 'rejected'
 
             if ([7, 20].includes(index)) {  // island
                 // cooldown
-                if (!this.checkTimeIsland(name, newVote.timestamp)) return 'cooldown'
+                if (!this.checkTimeIsland(uid, newVote.timestamp)) return 'cooldown'
 
                 // accepted
-                const idx = this.islandPool.findIndex(x => x.name === name)
+                const idx = this.islandPool.findIndex(x => x.uid === uid)
                 if (idx !== -1) this.islandPool.splice(idx, 1)
                 this.islandPool.push(newVote)
                 return 'accepted'
             } else {    // normal
                 // cooldown
-                if (!this.checkTime(name, newVote.timestamp)) return 'cooldown'
+                if (!this.checkTime(uid, newVote.timestamp)) return 'cooldown'
 
                 // accepted
-                const group = this.pool.filter(x => x.name === name)
+                const group = this.pool.filter(x => x.uid === uid)
                 if (group.length === 3) this.pool.splice(this.pool.indexOf(group[0]), 1)
                 this.pool.push(newVote)
                 return 'accepted'
             }
         },
-        checkTime(name: string, time: number) {
-            const group = this.pool.filter(x => x.name === name)
+        checkTime(uid: string, time: number) {
+            const group = this.pool.filter(x => x.uid === uid)
             if (group.length > 0) {
                 const last = group.slice(-1)[0]
                 return (time - last.timestamp) > 30_000
             } else return true
         },
-        checkTimeIsland(name: string, time: number) {
-            const last = this.islandPool.find(x => x.name === name)
+        checkTimeIsland(uid: string, time: number) {
+            const last = this.islandPool.find(x => x.uid === uid)
             if (last) {
                 return (time - last.timestamp) > 30_000
             } else return true
@@ -217,11 +212,11 @@ export const useBoardStore = defineStore('board', {
             }
         },
         remove(target: vote) {
-            this.usedList.push({ name: target.name, song: target.song })
-            this.pool.filter(x => x.name === target.name).forEach(x => {
+            this.usedList.push({ uid: target.uid, song: target.song })
+            this.pool.filter(x => x.uid === target.uid).forEach(x => {
                 this.pool.splice(this.pool.indexOf(x), 1)
             })
-            this.islandPool.filter(x => x.name === target.name).forEach(x => {
+            this.islandPool.filter(x => x.uid === target.uid).forEach(x => {
                 this.islandPool.splice(this.islandPool.indexOf(x), 1)
             })
         },
@@ -257,6 +252,7 @@ interface theme {
     stepped: number
 }
 export interface vote {
+    uid: string,
     name: string,
     theme: string,
     song: string,

--- a/src/stores/ConnectStore.ts
+++ b/src/stores/ConnectStore.ts
@@ -61,7 +61,7 @@ export const useConnectStore = defineStore('connection', {
             this.logs.push({ type, status, detail } as Log)
         },
         connectTwitch(begin: boolean, channel: string = "arpa__") {
-            if(this.socket_twitch) {
+            if (this.socket_twitch) {
                 return
             }
             this.socket_twitch = new WebSocket('wss://irc-ws.chat.twitch.tv')
@@ -145,7 +145,7 @@ export const useConnectStore = defineStore('connection', {
             }
         },
         connectToonation(payload: string) {
-            if (!this.socket_toonation) {
+            if (this.socket_toonation) {
                 return
             }
             this.socket_toonation = new WebSocket('wss://toon.at:8071/' + payload)

--- a/src/stores/ConnectStore.ts
+++ b/src/stores/ConnectStore.ts
@@ -61,6 +61,9 @@ export const useConnectStore = defineStore('connection', {
             this.logs.push({ type, status, detail } as Log)
         },
         connectTwitch(begin: boolean, channel: string = "arpa__") {
+            if(this.socket_twitch) {
+                return
+            }
             this.socket_twitch = new WebSocket('wss://irc-ws.chat.twitch.tv')
             this.result({
                 type: 'twitch',
@@ -142,6 +145,9 @@ export const useConnectStore = defineStore('connection', {
             }
         },
         connectToonation(payload: string) {
+            if (!this.socket_toonation) {
+                return
+            }
             this.socket_toonation = new WebSocket('wss://toon.at:8071/' + payload)
             this.result({
                 type: 'toonation',
@@ -179,6 +185,7 @@ export const useConnectStore = defineStore('connection', {
                         status: 'disconnected'
                     })
                 }
+                this.socket_toonation = null
                 setTimeout(this.connectToonation, this.retryCount > 0 ? 1000 : 10, payload);
                 this.retryCount++
             }

--- a/src/stores/ItemStore.ts
+++ b/src/stores/ItemStore.ts
@@ -1,8 +1,6 @@
 import { defineStore } from "pinia";
 import { remainder } from "../scripts/Calculate";
 
-export const ITEMS_PER_PAGE = 4
-
 export const useItemStore = defineStore('items', {
     state() {
         return {
@@ -35,10 +33,13 @@ export const useItemStore = defineStore('items', {
         },
         checkType(name: string) {
             const match = name.match(regex)
-            if (match) return {
-                key: String(match.groups?.option.trim()),
+            if(!match) return
+
+            const option = name.replace(regex, '').trim()
+            return {
+                key: option,
                 count: Number(match.groups?.count),
-                type: String(match.groups?.type) as '턴' | '곡' | '개'
+                type: ITEM_LABEL_MAPPING[match.groups?.type!]
             }
         },
 
@@ -83,4 +84,14 @@ interface item{
     type: '턴' | '곡' | '개'
 }
 
-const regex = /\((?<count>\d+)(?<type>턴|곡|개)\)(?<option>.+)/
+const regex = /\((?<count>\d+)(?<type>[턴곡개회번])\)/
+
+export const ITEMS_PER_PAGE = 4
+
+const ITEM_LABEL_MAPPING: { [key: string]: item["type"] } = {
+    턴: '턴',
+    곡: '곡',
+    개: '개',
+    회: '개',
+    번: '개'
+}

--- a/src/style.css
+++ b/src/style.css
@@ -61,8 +61,6 @@ input, select {
     -webkit-background-clip: text;
     color: transparent;
 }
-.iidx-title-inline {
-}
 .iidx-title.new > span, .iidx-title-inline.new {
     background-image: linear-gradient(to bottom, #fff, #2fe);
 }


### PR DESCRIPTION
## 디자인
- `.center`의 가로 크기 조정
- 4px 보더를 2px로 줄임
- `.block-header`에도 보더를 추가
- 시작 칸을 우클릭해서 직전 뽑기 칸으로 가기
- Wheel 캔버스 크기를 적당히 줄이고(640) 중앙정렬 및 오버플로우 방지


## 기술적
- IRC 파싱 로직을 변경 (풀버전으로)
- websocket이 존재할 경우 재연결하지 않도록 수정 (사실 개발중에만 상관있는거라 건들지 말까 싶긴 한데...)
- 모든 중복 처리를 `uid` (실제로는 IRC 유저네임 내지 `login`)으로 하도록 수정 - CAP REQ 실패해도 ㄱㅊ
- `usedList`를 그냥 `vote[]`로 변경